### PR TITLE
Fix Supabase keep-alive workflow

### DIFF
--- a/.github/workflows/supabase-keep-alive.yml
+++ b/.github/workflows/supabase-keep-alive.yml
@@ -9,24 +9,10 @@ jobs:
   ping:
     runs-on: ubuntu-latest
     steps:
-      - name: Query organizations (primary ping)
+      # A read through PostgREST counts as project activity, which is all
+      # Supabase needs to keep the free-tier project from pausing.
+      - name: Query organizations (keep-alive ping)
         run: |
           curl -f -X GET "${{ secrets.SUPABASE_URL }}/rest/v1/organizations?select=id&limit=1" \
-            -H "apikey: ${{ secrets.SUPABASE_ANON_KEY }}" \
-            -H "Authorization: Bearer ${{ secrets.SUPABASE_ANON_KEY }}"
-
-      - name: Insert keep-alive record
-        run: |
-          curl -f -X POST "${{ secrets.SUPABASE_URL }}/rest/v1/keep_alive" \
-            -H "apikey: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}" \
-            -H "Authorization: Bearer ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}" \
-            -H "Content-Type: application/json" \
-            -H "Prefer: return=minimal" \
-            -d "{\"pinged_at\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}"
-
-      - name: Delete records older than 30 days
-        run: |
-          CUTOFF=$(date -u -d '30 days ago' +%Y-%m-%dT%H:%M:%SZ)
-          curl -f -X DELETE "${{ secrets.SUPABASE_URL }}/rest/v1/keep_alive?pinged_at=lt.${CUTOFF}" \
-            -H "apikey: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}" \
-            -H "Authorization: Bearer ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}"
+            -H "apikey: ${{ secrets.VITE_SUPABASE_ANON_KEY }}" \
+            -H "Authorization: Bearer ${{ secrets.VITE_SUPABASE_ANON_KEY }}"


### PR DESCRIPTION
The scheduled keep-alive workflow failed on every run:

- It referenced `secrets.SUPABASE_ANON_KEY`, which does not exist (the repo secret is `VITE_SUPABASE_ANON_KEY`), so the request went out with an empty `apikey` header and Supabase returned 401.
- The insert/cleanup steps targeted a `public.keep_alive` table that does not exist in the project and would have failed next.

This keeps a single anon-key SELECT ping (verified to return 200 against the live project), which is sufficient database activity to prevent free-tier pausing.